### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.4.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.3.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ to `/opt/stackstorm/configs/typeform.yaml` and edit as required.
 
 See the Sensors and Actions sections below for configuration details.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Sensors
 
 This pack ships with a sensor that checks the Typeform API for submissions to a given form, then compares that list against a MySQL database.  If the submission is not yet in the database, it submits a trigger with the information from the submission.  Currently the sensor is limited to a specific format of the form.  Required fields in the config file are:

--- a/actions/get_results.yaml
+++ b/actions/get_results.yaml
@@ -1,6 +1,6 @@
 ---
   name: "get_results"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Get Typeform registration results"
   enabled: true
   entry_point: "get_results.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description : Typeform service integration pack
 keywords :
   - typeform
   - web forms
-version : 0.3.0
+version : 0.4.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.