### PR TITLE
Use mysqlclient instead of MySQL-python (dead project)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.5.0
+
+- Use the mysqlclient project instead of the MySQL-python (dead) project
+
 # 0.4.1
 
 - Import `Action` from `st2comon.runners.base_action`

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description : Typeform service integration pack
 keywords :
   - typeform
   - web forms
-version: 0.4.1
+version: 0.5.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ndg-httpsclient
 pyasn1
 PyOpenSSL
-MySQL-python
+mysqlclient


### PR DESCRIPTION
The [MySQLdb1 project](https://github.com/farcepest/MySQLdb1) is dead and hasn't been touched in six years.

The [mysqlclient package](https://github.com/PyMySQL/mysqlclient-python) is a fork and a drop-in replacement that is still actively developed and supports Python 3. Use it instead.

This should fix the weekly CI runs for this pack, however this is untested.